### PR TITLE
Dispose controllers in AddBenefitScreen

### DIFF
--- a/lib/screens/add_benefit_screen.dart
+++ b/lib/screens/add_benefit_screen.dart
@@ -41,6 +41,13 @@ class _AddBenefitScreenState extends State<AddBenefitScreen> {
   }
 
   @override
+  void dispose() {
+    _detailsController.dispose();
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Add New Benefit')),


### PR DESCRIPTION
## Summary
- dispose text controllers in _AddBenefitScreenState

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a28226848332987c645f364350dd