### PR TITLE
docs: refine README for yuutai-map project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# flutter_stock
+# Shareholder Benefit Map (yuutai-map)
 
-A new Flutter project.
+株主優待情報を登録し、地図上で優待店舗を確認できる Flutter アプリです。
 
-## Getting Started
+## 主な機能
+- 株主優待の登録・編集
+- Google マップを用いた優待スポットの表示
+- 現在地の取得による近隣検索
 
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## セットアップ
+1. Flutter 3.8.1 以降をインストールします。
+2. このリポジトリをクローンし、ディレクトリに移動します。
+3. `.env` に Firebase や Google Maps の API キーを設定します。
+4. 依存関係を取得します。
+   ```bash
+   flutter pub get
+   ```
+5. アプリを起動します。
+   ```bash
+   flutter run
+   ```


### PR DESCRIPTION
## Summary
- rename README title and overview to Shareholder Benefit Map (yuutai-map)
- add app features and project-specific setup instructions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a287e7848332b61a5cf5b7d8e327